### PR TITLE
Switching maven-bundle-plugin to 3.0 version

### DIFF
--- a/maven/aem-global-parent/pom.xml
+++ b/maven/aem-global-parent/pom.xml
@@ -129,7 +129,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.5.5-R1680303</version>
+          <version>3.0.0</version>
           <extensions>true</extensions>
           <configuration>
             <instructions>


### PR DESCRIPTION
Switching to 3.0 version because version 2.5.5-R1680303 is not available in public repositories.
