### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/maven/aem-dependencies/5.5.0/pom.xml
+++ b/maven/aem-dependencies/5.5.0/pom.xml
@@ -1263,7 +1263,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
       <dependency>
         <groupId>com.day.cq</groupId>

--- a/maven/aem-dependencies/6.0.0/pom.xml
+++ b/maven/aem-dependencies/6.0.0/pom.xml
@@ -230,7 +230,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
 
       <!-- from crx-quickstart/app/cq-quickstart-*-standalone.jar/resources/install/14 -->

--- a/maven/aem-dependencies/6.1.0/pom.xml
+++ b/maven/aem-dependencies/6.1.0/pom.xml
@@ -226,7 +226,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
 
       <!-- from crx-quickstart/app/cq-quickstart-*-standalone.jar/resources/install/14 -->


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/