### PR TITLE
shortRevisionLength Setting

### DIFF
--- a/maven/global-parent/pom.xml
+++ b/maven/global-parent/pom.xml
@@ -413,6 +413,7 @@
           <doUpdate>false</doUpdate>
           <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
           <format>{0}</format>
+          <shortRevisionLength>8</shortRevisionLength>
           <items>
             <item>scmVersion</item>
           </items>


### PR DESCRIPTION
I think it would be useful to use a shorter Revision Name espacially for git commits.
currently the complete revision is used 