### PR TITLE
change rulesetRef from basic to empty

### DIFF
--- a/maven/global-build-tools/src/main/resources/global-build-tools/pmd-ruleset.xml
+++ b/maven/global-build-tools/src/main/resources/global-build-tools/pmd-ruleset.xml
@@ -32,7 +32,7 @@
   <!-- Exclude test classes -->
   <exclude-pattern>.*/src/test/.*</exclude-pattern>
 
-  <rule ref="rulesets/java/basic.xml">
+  <rule ref="rulesets/java/empty.xml">
     <exclude name="EmptyCatchBlock"/>  <!-- false positives with empty blocks with comments as well -->
     <exclude name="EmptyIfStmt"/>
   </rule>
@@ -78,7 +78,6 @@
     <exclude name="UseConcurrentHashMap"/>  <!-- triggers on cases where concurrency is not an issue -->
     <exclude name="NullAssignment"/>
     <exclude name="AvoidUsingShortType"/>
-    <exclude name="BooleanInversion"/>
     <exclude name="AvoidPrefixingMethodParameters"/>
   </rule>
   <rule ref="rulesets/java/design.xml">


### PR DESCRIPTION
As described in  https://pmd.github.io/pmd-5.5.1/pmd-java/rules/index.html#Empty_Code, emptyStatements are referred in "empty" instead "basic" RuleSet.
"BooleanInversion" Rule was removed in pmd 5.3