### PR TITLE
Fix relative paths passed to addFile

### DIFF
--- a/commons/content-package-builder/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/ContentPackage.java
+++ b/commons/content-package-builder/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/ContentPackage.java
@@ -55,6 +55,7 @@ import org.apache.jackrabbit.vault.packaging.PackageProperties;
 import org.apache.jackrabbit.vault.util.PlatformNameFormat;
 import org.w3c.dom.Document;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 
 import io.wcm.tooling.commons.contentpackagebuilder.element.ContentElement;
@@ -184,12 +185,17 @@ public final class ContentPackage implements Closeable {
 
   /**
    * If path parts contain namespace definitions they need to be escaped for the ZIP file.
-   * Example: oak:index -> _oak_index
+   * Example: oak:index -> jcr_root/_oak_index
    * @param path Path
    * @return Safe path
    */
-  private String buildJcrPathForZip(String path) {
-    return ROOT_DIR + PlatformNameFormat.getPlatformPath(StringUtils.defaultString(path));
+  @VisibleForTesting
+  static String buildJcrPathForZip(final String path) {
+    String normalizedPath = StringUtils.defaultString(path);
+    if (!normalizedPath.startsWith("/")) {
+      normalizedPath = "/" + normalizedPath;
+    }
+    return ROOT_DIR + PlatformNameFormat.getPlatformPath(normalizedPath);
   }
 
   /**

--- a/commons/content-package-builder/src/test/java/io/wcm/tooling/commons/contentpackagebuilder/ContentPackageTest.java
+++ b/commons/content-package-builder/src/test/java/io/wcm/tooling/commons/contentpackagebuilder/ContentPackageTest.java
@@ -1,0 +1,14 @@
+package io.wcm.tooling.commons.contentpackagebuilder;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ContentPackageTest {
+  @Test
+  public void buildJcrPathForZip() {
+    assertEquals("jcr_root/_oak_index", ContentPackage.buildJcrPathForZip("oak:index"));
+    assertEquals("jcr_root/etc/content", ContentPackage.buildJcrPathForZip("etc/content"));
+    assertEquals("jcr_root/etc/content", ContentPackage.buildJcrPathForZip("/etc/content"));
+  }
+}


### PR DESCRIPTION
We tried to upgrade AEM Content Package Builder to 1.2.0, from 1.1.4.

Generated content packages failed in that they had directories like `jcr_rootapps` instead of `jcr_root/apps`. We realized we were passing relative paths to `addFile`. However, the documentation does not prohibit this (and the javadoc example in buildJcrPathForZip is also using a relative path). This patch re-instates this previous behaviour and adds some unit tests for it.