### PR TITLE
Providing Package Installation through Composum (Sling) (Issue WTOOL-30)

### DIFF
--- a/commons/crx-packmgr-helper/changes.xml
+++ b/commons/crx-packmgr-helper/changes.xml
@@ -27,6 +27,10 @@
       <action type="add" dev="sseifert" issue="WTOOL-30">
         Set package versions.
       </action>
+      <action type="add" dev="schaefera" issue="WTOOL-29">
+        Added support for the package installation through
+        Composum.
+      </action>
     </release>
 
     <release version="1.0.0" date="2017-02-08">

--- a/commons/crx-packmgr-helper/pom.xml
+++ b/commons/crx-packmgr-helper/pom.xml
@@ -31,7 +31,7 @@
   <groupId>io.wcm.tooling.commons</groupId>
   <artifactId>io.wcm.tooling.commons.crx-packmgr-helper</artifactId>
   <version>1.0.1-SNAPSHOT</version>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <name>CRX Package Manager Helper</name>
   <description>Java Library for uploading and downloading AEM content packages via CRX Package Manager.</description>

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/PackageManagerHelper.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/PackageManagerHelper.java
@@ -28,6 +28,7 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
 
+import io.wcm.tooling.commons.packmgr.httpaction.PackageManagerHtmlCall;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.http.HttpException;
@@ -184,6 +185,19 @@ public final class PackageManagerHelper {
   public JSONObject executePackageManagerMethodJson(CloseableHttpClient httpClient, HttpRequestBase method) {
     PackageManagerJsonCall call = new PackageManagerJsonCall(httpClient, method, log);
     return executeHttpCallWithRetry(call, 0);
+  }
+
+  /**
+   * Execute CRX HTTP Package manager method and parse/output xml response.
+   * @param httpClient Http client
+   * @param method Get or Post method
+   * @return Response from HTML server
+   */
+  public String executePackageManagerMethodHtml(CloseableHttpClient httpClient, HttpRequestBase method) {
+    PackageManagerHtmlCall call = new PackageManagerHtmlCall(httpClient, method, log);
+    String message = executeHttpCallWithRetry(call, 0);
+//    log.info(message);
+    return message;
   }
 
   /**

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/httpaction/PackageManagerHtmlCall.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/httpaction/PackageManagerHtmlCall.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2014 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.tooling.commons.packmgr.httpaction;
+
+import io.wcm.tooling.commons.packmgr.Logger;
+import io.wcm.tooling.commons.packmgr.PackageManagerException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Call that parses a packager manager HTML response and returns the contained message as plain text.
+ */
+public final class PackageManagerHtmlCall implements HttpCall<String> {
+
+  private final CloseableHttpClient httpClient;
+  private final HttpRequestBase method;
+  private final Logger log;
+
+  /**
+   * @param httpClient HTTP client
+   * @param method HTTP method
+   * @param log Logger
+   */
+  public PackageManagerHtmlCall(CloseableHttpClient httpClient, HttpRequestBase method, Logger log) {
+    this.httpClient = httpClient;
+    this.method = method;
+    this.log = log;
+  }
+
+  @Override
+  public String execute() {
+    if (log.isDebugEnabled()) {
+      log.debug("Call URL: " + method.getURI());
+    }
+
+    try (CloseableHttpResponse response = httpClient.execute(method)) {
+      String responseString = EntityUtils.toString(response.getEntity());
+
+      if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+
+        // debug output whole xml
+        if (log.isDebugEnabled()) {
+          log.debug("CRX Package Manager Response:\n" + responseString);
+        }
+
+//        // remove all HTML tags and special conctent
+//        final Pattern HTML_STYLE = Pattern.compile("<style[^<>]*>[^<>]*</style>", Pattern.MULTILINE | Pattern.DOTALL);
+//        final Pattern HTML_JAVASCRIPT = Pattern.compile("<script[^<>]*>[^<>]*</script>", Pattern.MULTILINE | Pattern.DOTALL);
+//        final Pattern HTML_ANYTAG = Pattern.compile("<[^<>]*>");
+//
+//        responseString = HTML_STYLE.matcher(responseString).replaceAll("");
+//        responseString = HTML_JAVASCRIPT.matcher(responseString).replaceAll("");
+//        responseString = HTML_ANYTAG.matcher(responseString).replaceAll("");
+//        responseString = StringUtils.replace(responseString, "&nbsp;", " ");
+
+        return responseString;
+      }
+      else {
+        throw new PackageManagerException("Call failed with HTTP status " + response.getStatusLine().getStatusCode()
+            + " " + response.getStatusLine().getReasonPhrase() + "\n"
+            + responseString);
+      }
+
+    }
+    catch (IOException ex) {
+      throw new PackageManagerException("Http method failed.", ex);
+    }
+  }
+
+}

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/httpaction/package-info.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/httpaction/package-info.java
@@ -20,5 +20,5 @@
 /**
  * HTTP action
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package io.wcm.tooling.commons.packmgr.httpaction;

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/PackageInstaller.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/PackageInstaller.java
@@ -82,7 +82,9 @@ public final class PackageInstaller {
       }
 
       VendorPackageInstaller installer = VendorInstallerFactory.getPackageInstaller(props.getPackageManagerUrl());
-      installer.installPackage(packageFile, pkgmgr, httpClient, log);
+      if(installer != null) {
+        installer.installPackage(packageFile, pkgmgr, httpClient, log);
+      }
     }
     catch (IOException ex) {
       throw new PackageManagerException("Install operation failed.", ex);

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/VendorInstallerFactory.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/VendorInstallerFactory.java
@@ -1,23 +1,82 @@
 package io.wcm.tooling.commons.packmgr.install;
 
+import io.wcm.tooling.commons.packmgr.Logger;
+import io.wcm.tooling.commons.packmgr.PackageManagerException;
 import io.wcm.tooling.commons.packmgr.install.composum.ComposumPackageInstaller;
 import io.wcm.tooling.commons.packmgr.install.crx.CrxPackageInstaller;
 
 /**
- * Created by schaefa on 4/19/17.
+ * This factory provides Package Manager specific handling
+ * provided by different vendors like CRX Package Manager
+ * and Composum
  */
 public class VendorInstallerFactory {
 
-    public static VendorPackageInstaller getPackageInstaller(String url) {
-        if(url != null) {
-            if(url.indexOf("/bin/cpm/package.service") >= 0) {
-                return new ComposumPackageInstaller(url);
-            } else {
-                return new CrxPackageInstaller(url);
-            }
-        } else {
-            //AS TODO log error or throw exception
-            return null;
+    public static final String COMPOSUM_URL = "/bin/cpm/";
+    public static final String CRX_URL = "/crx/packmgr/service";
+
+    public enum Service { crx, composum, unsupported };
+
+    /**
+     * Identifies the Service Vendor based on the given URL
+     * @param url Base URL to check
+     * @return Service Enum found or unsupported
+     */
+    public static Service identify(String url) {
+        Service answer = Service.unsupported;
+        int index = url.indexOf(COMPOSUM_URL);
+        if(index > 0) {
+            answer = Service.composum;
         }
+        else {
+            index = url.indexOf(CRX_URL);
+            if (index > 0) {
+                answer = Service.crx;
+            }
+        }
+        return answer;
+    }
+
+    /**
+     * Returns the Base Url of a given URL with
+     * based on its Vendors from the URL
+     * @param url Service URL
+     * @return Base URL if service vendor was found otherwise the given URL
+     */
+    public static String getBaseUrl(String url, Logger logger) {
+        String answer = url;
+        switch(identify(url)) {
+            case composum:
+                answer = url.substring(0, url.indexOf(COMPOSUM_URL));
+                break;
+            case crx:
+                answer = url.substring(0, url.indexOf(CRX_URL));
+                break;
+            default:
+                logger.error("Given URL is not supported: " + url);
+        }
+        return answer;
+    }
+
+    /**
+     * Provides the Installer of the Service Vendor
+     * @param url Base URL of the service
+     * @return Installer if URL is supported otherwise null
+     */
+    public static VendorPackageInstaller getPackageInstaller(String url)
+        throws PackageManagerException
+    {
+        VendorPackageInstaller answer;
+        switch(identify(url)) {
+            case composum:
+                answer = new ComposumPackageInstaller(url);
+                break;
+            case crx:
+                answer = new CrxPackageInstaller(url);
+                break;
+            default:
+                throw new PackageManagerException("Given URL is not supported: " + url);
+        }
+        return answer;
     }
 }

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/VendorInstallerFactory.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/VendorInstallerFactory.java
@@ -1,0 +1,23 @@
+package io.wcm.tooling.commons.packmgr.install;
+
+import io.wcm.tooling.commons.packmgr.install.composum.ComposumPackageInstaller;
+import io.wcm.tooling.commons.packmgr.install.crx.CrxPackageInstaller;
+
+/**
+ * Created by schaefa on 4/19/17.
+ */
+public class VendorInstallerFactory {
+
+    public static VendorPackageInstaller getPackageInstaller(String url) {
+        if(url != null) {
+            if(url.indexOf("/bin/cpm/package.service") >= 0) {
+                return new ComposumPackageInstaller(url);
+            } else {
+                return new CrxPackageInstaller(url);
+            }
+        } else {
+            //AS TODO log error or throw exception
+            return null;
+        }
+    }
+}

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/VendorPackageInstaller.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/VendorPackageInstaller.java
@@ -1,0 +1,17 @@
+package io.wcm.tooling.commons.packmgr.install;
+
+import io.wcm.tooling.commons.packmgr.Logger;
+import io.wcm.tooling.commons.packmgr.PackageManagerException;
+import io.wcm.tooling.commons.packmgr.PackageManagerHelper;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.IOException;
+
+/**
+ * Created by schaefa on 4/19/17.
+ */
+public interface VendorPackageInstaller {
+
+    public void installPackage(PackageFile packageFile, PackageManagerHelper pkgmgr, CloseableHttpClient httpClient, Logger log)
+        throws IOException, PackageManagerException;
+}

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/VendorPackageInstaller.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/VendorPackageInstaller.java
@@ -8,10 +8,19 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import java.io.IOException;
 
 /**
- * Created by schaefa on 4/19/17.
+ * Interface any Vendor Package Installer must provide
  */
 public interface VendorPackageInstaller {
 
+    /**
+     * Install a Package
+     * @param packageFile Package to be installed
+     * @param pkgmgr Package Manager
+     * @param httpClient Http Client used to call the service
+     * @param log Logger to report issues
+     * @throws IOException If calls to the Web Service fail
+     * @throws PackageManagerException If the package installation failed
+     */
     public void installPackage(PackageFile packageFile, PackageManagerHelper pkgmgr, CloseableHttpClient httpClient, Logger log)
         throws IOException, PackageManagerException;
 }

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/composum/ComposumPackageInstaller.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/composum/ComposumPackageInstaller.java
@@ -7,19 +7,32 @@ import io.wcm.tooling.commons.packmgr.install.PackageFile;
 import io.wcm.tooling.commons.packmgr.install.VendorPackageInstaller;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.json.JSONObject;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
+import java.io.StringBufferInputStream;
+import java.net.URISyntaxException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static io.wcm.tooling.commons.packmgr.PackageManagerHelper.CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX;
 
 /**
- * Created by schaefa on 4/19/17.
+ * Vendor Installer for Composum
  */
 public class ComposumPackageInstaller
     implements VendorPackageInstaller
 {
+
     private String url;
 
     public ComposumPackageInstaller(String url) {
@@ -31,7 +44,10 @@ public class ComposumPackageInstaller
         throws IOException, PackageManagerException
     {
         // prepare post method
-        HttpPost post = new HttpPost(url);
+        int index = url.indexOf("/bin/cpm/");
+        String baseUrl = url.substring(0, index) + "/bin/cpm/package.";
+        String uploadUrl = baseUrl + "upload.json";
+        HttpPost post = new HttpPost(uploadUrl);
         MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create()
             .addBinaryBody("file", packageFile.getFile());
         if (packageFile.isForce()) {
@@ -40,17 +56,51 @@ public class ComposumPackageInstaller
         post.setEntity(entityBuilder.build());
 
         // execute post
-        String response = pkgmgr.executePackageManagerMethodHtml(httpClient, post);
-        boolean success = response.indexOf("<status code=\"200\">ok</status>") > 0;
-
+        JSONObject jsonResponse = pkgmgr.executePackageManagerMethodJson(httpClient, post);
+        String status = jsonResponse.optString("status", "not-found");
+        boolean success = "successful".equals(status);
+        String path = jsonResponse.optString("path", null);
         if (success) {
-            //AS TODO: As of now we do the upload and installation in one step so no futher action needed
+            if(packageFile.isInstall()) {
+                log.info("Package uploaded, now installing...");
+
+                String installUrl = baseUrl + "install.json" + path;
+                post = new HttpPost(installUrl);
+
+                // execute post
+                JSONObject jsonResponseInstallation = pkgmgr.executePackageManagerMethodJson(httpClient, post);
+                String installationStatus = jsonResponseInstallation.optString("status", "not-found");
+                if(!"done".equals(installationStatus)) {
+                    throw new PackageManagerException("Package installation failed: " + status);
+                }
+
+                // delay further processing after install (if activated)
+                delay(packageFile.getDelayAfterInstallSec(), log);
+
+                // after install: if bundles are still stopping/starting, wait for completion
+                pkgmgr.waitForBundlesActivation(httpClient);
+            } else {
+                log.info("Package uploaded successfully (without installing).");
+            }
         }
-        else if (StringUtils.startsWith(response, CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX) && !packageFile.isForce()) {
-            log.info("Package skipped because it was already uploaded.");
-        }
+// As of now the force flag is ignored by Composum and it fill upload not matter what (ticket pending: https://github.com/ist-dresden/composum/issues/73)
+//        else if (StringUtils.startsWith(response, CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX) && !packageFile.isForce()) {
+//            log.info("Package skipped because it was already uploaded.");
+//        }
         else {
-            throw new PackageManagerException("Package upload failed: " + response);
+            throw new PackageManagerException("Package upload failed: " + status);
+        }
+    }
+
+    private void delay(int seconds, Logger log) {
+        if (seconds > 0) {
+            log.info("Wait for " + seconds + " seconds after package install...");
+            try {
+                Thread.sleep(seconds * 1000);
+            }
+            catch (InterruptedException ex) {
+                // ignore
+            }
         }
     }
 }

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/composum/ComposumPackageInstaller.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/composum/ComposumPackageInstaller.java
@@ -1,0 +1,56 @@
+package io.wcm.tooling.commons.packmgr.install.composum;
+
+import io.wcm.tooling.commons.packmgr.Logger;
+import io.wcm.tooling.commons.packmgr.PackageManagerException;
+import io.wcm.tooling.commons.packmgr.PackageManagerHelper;
+import io.wcm.tooling.commons.packmgr.install.PackageFile;
+import io.wcm.tooling.commons.packmgr.install.VendorPackageInstaller;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.IOException;
+
+import static io.wcm.tooling.commons.packmgr.PackageManagerHelper.CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX;
+
+/**
+ * Created by schaefa on 4/19/17.
+ */
+public class ComposumPackageInstaller
+    implements VendorPackageInstaller
+{
+    private String url;
+
+    public ComposumPackageInstaller(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public void installPackage(PackageFile packageFile, PackageManagerHelper pkgmgr, CloseableHttpClient httpClient, Logger log)
+        throws IOException, PackageManagerException
+    {
+        // prepare post method
+        HttpPost post = new HttpPost(url);
+        MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create()
+            .addBinaryBody("file", packageFile.getFile());
+        if (packageFile.isForce()) {
+            entityBuilder.addTextBody("force", "true");
+        }
+        post.setEntity(entityBuilder.build());
+
+        // execute post
+        String response = pkgmgr.executePackageManagerMethodHtml(httpClient, post);
+        boolean success = response.indexOf("<status code=\"200\">ok</status>") > 0;
+
+        if (success) {
+            //AS TODO: As of now we do the upload and installation in one step so no futher action needed
+        }
+        else if (StringUtils.startsWith(response, CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX) && !packageFile.isForce()) {
+            log.info("Package skipped because it was already uploaded.");
+        }
+        else {
+            throw new PackageManagerException("Package upload failed: " + response);
+        }
+    }
+}

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/composum/package-info.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/composum/package-info.java
@@ -18,7 +18,7 @@
  * #L%
  */
 /**
- * HTTP action
+ * Package installer for Composum Package Manager
  */
 @org.osgi.annotation.versioning.Version("1.0.1")
-package io.wcm.tooling.commons.packmgr.httpaction;
+package io.wcm.tooling.commons.packmgr.install.composum;

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/crx/CrxPackageInstaller.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/crx/CrxPackageInstaller.java
@@ -1,0 +1,95 @@
+package io.wcm.tooling.commons.packmgr.install.crx;
+
+import io.wcm.tooling.commons.packmgr.Logger;
+import io.wcm.tooling.commons.packmgr.PackageManagerException;
+import io.wcm.tooling.commons.packmgr.PackageManagerHelper;
+import io.wcm.tooling.commons.packmgr.install.PackageFile;
+import io.wcm.tooling.commons.packmgr.install.VendorPackageInstaller;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static io.wcm.tooling.commons.packmgr.PackageManagerHelper.CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX;
+
+/**
+ * Created by schaefa on 4/19/17.
+ */
+public class CrxPackageInstaller
+    implements VendorPackageInstaller
+{
+    private String url;
+
+    public CrxPackageInstaller(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public void installPackage(PackageFile packageFile, PackageManagerHelper pkgmgr, CloseableHttpClient httpClient, Logger log)
+        throws IOException, PackageManagerException
+    {
+        // prepare post method
+        HttpPost post = new HttpPost(url + "/.json?cmd=upload");
+        MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create()
+            .addBinaryBody("package", packageFile.getFile());
+        if (packageFile.isForce()) {
+            entityBuilder.addTextBody("force", "true");
+        }
+        post.setEntity(entityBuilder.build());
+
+        // execute post
+        JSONObject jsonResponse = pkgmgr.executePackageManagerMethodJson(httpClient, post);
+        boolean success = jsonResponse.optBoolean("success", false);
+        String msg = jsonResponse.optString("msg", null);
+        String path = jsonResponse.optString("path", null);
+        if (success) {
+            if(packageFile.isInstall()) {
+                log.info("Package uploaded, now installing...");
+
+                try {
+                    post = new HttpPost(url + "/console.html" + new URIBuilder().setPath(path).build().getRawPath() + "?cmd=install" + (packageFile.isRecursive() ? "&recursive=true" : ""));
+                } catch(URISyntaxException ex) {
+                    throw new PackageManagerException("Invalid path: " + path, ex);
+                }
+
+                // execute post
+                pkgmgr.executePackageManagerMethodHtml(httpClient, post, 0);
+
+                // delay further processing after install (if activated)
+                delay(packageFile.getDelayAfterInstallSec(), log);
+
+                // after install: if bundles are still stopping/starting, wait for completion
+                pkgmgr.waitForBundlesActivation(httpClient);
+            } else {
+                log.info("Package uploaded successfully (without installing).");
+            }
+        }
+        //      else if (StringUtils.startsWith(msg, CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX) && !packageFile.isForce()) {
+        else if (StringUtils.startsWith(msg, CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX) && !packageFile.isForce()) {
+            log.info("Package skipped because it was already uploaded.");
+        }
+        else {
+            //        throw new PackageManagerException("Package upload failed: " + msg);
+            throw new PackageManagerException("Package upload failed: " + msg);
+        }
+
+    }
+
+    private void delay(int seconds, Logger log) {
+        if (seconds > 0) {
+            log.info("Wait for " + seconds + " seconds after package install...");
+            try {
+                Thread.sleep(seconds * 1000);
+            }
+            catch (InterruptedException ex) {
+                // ignore
+            }
+        }
+    }
+}

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/crx/CrxPackageInstaller.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/crx/CrxPackageInstaller.java
@@ -19,7 +19,7 @@ import java.net.URISyntaxException;
 import static io.wcm.tooling.commons.packmgr.PackageManagerHelper.CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX;
 
 /**
- * Created by schaefa on 4/19/17.
+ * Package Installer for AEM's CRX Package Manager
  */
 public class CrxPackageInstaller
     implements VendorPackageInstaller
@@ -70,7 +70,6 @@ public class CrxPackageInstaller
                 log.info("Package uploaded successfully (without installing).");
             }
         }
-        //      else if (StringUtils.startsWith(msg, CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX) && !packageFile.isForce()) {
         else if (StringUtils.startsWith(msg, CRX_PACKAGE_EXISTS_ERROR_MESSAGE_PREFIX) && !packageFile.isForce()) {
             log.info("Package skipped because it was already uploaded.");
         }

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/crx/package-info.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/crx/package-info.java
@@ -18,7 +18,7 @@
  * #L%
  */
 /**
- * HTTP action
+ * Package installer for CRX Package Manager
  */
 @org.osgi.annotation.versioning.Version("1.0.1")
-package io.wcm.tooling.commons.packmgr.httpaction;
+package io.wcm.tooling.commons.packmgr.install.crx;

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/package-info.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Package installer
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package io.wcm.tooling.commons.packmgr.install;

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/package-info.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/install/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Package installer
  */
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.0.1")
 package io.wcm.tooling.commons.packmgr.install;

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/package-info.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/package-info.java
@@ -20,5 +20,5 @@
 /**
  * CRX Package Manager Helper
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package io.wcm.tooling.commons.packmgr;

--- a/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/package-info.java
+++ b/commons/crx-packmgr-helper/src/main/java/io/wcm/tooling/commons/packmgr/package-info.java
@@ -20,5 +20,5 @@
 /**
  * CRX Package Manager Helper
  */
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.0.1")
 package io.wcm.tooling.commons.packmgr;

--- a/maven/plugins/wcmio-content-package-maven-plugin/pom.xml
+++ b/maven/plugins/wcmio-content-package-maven-plugin/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>io.wcm.tooling.commons</groupId>
       <artifactId>io.wcm.tooling.commons.crx-packmgr-helper</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  wcm.io
+  %%
+  Copyright (C) 2014 wcm.io
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>default</id>
+
+      <repositories>
+
+        <repository>
+          <id>central</id>
+          <url>http://repo1.maven.org/maven2/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+
+        <repository>
+          <id>adobe-public-releases</id>
+          <name>Adobe Public Repository</name>
+          <url>https://repo.adobe.com/nexus/content/groups/public/</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+
+        <repository>
+          <id>wcm-io-apache-intermediate-release</id>
+          <url>http://wcm.io/maven/repositories/apache-intermediate-release</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        
+        <repository>
+          <id>netbeans-releases</id>
+          <name>Netbeans Repository</name>
+          <url>http://bits.netbeans.org/nexus/content/groups/netbeans</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        
+        <repository>
+          <id>oss-snapshots</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+
+        <repository>
+          <id>apache-snapshots</id>
+          <url>http://repository.apache.org/snapshots</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+
+      </repositories>
+
+      <pluginRepositories>
+
+        <pluginRepository>
+          <id>central</id>
+          <url>http://repo1.maven.org/maven2/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+
+        <pluginRepository>
+          <id>adobe-public-releases</id>
+          <name>Adobe Public Repository</name>
+          <url>https://repo.adobe.com/nexus/content/groups/public/</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+
+        <pluginRepository>
+          <id>wcm-io-apache-intermediate-release</id>
+          <url>http://wcm.io/maven/repositories/apache-intermediate-release</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+
+        <pluginRepository>
+          <id>oss-snapshots</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+
+        <pluginRepository>
+          <id>apache-snapshots</id>
+          <url>http://repository.apache.org/snapshots</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+
+      </pluginRepositories>
+
+    </profile>
+
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>default</activeProfile>
+  </activeProfiles>
+
+</settings>


### PR DESCRIPTION
This PR provides a way to install a JCR Content Package both to CRX Packmgr on AEM as well as on Composum on Sling / AEM. For now the selection of the installation is done based on the URL. If the URL contains /bin/cqm/package.service an installation is made against Composum.

For now the Composum installation will only work if the "bundleStatusURL" is set to "-" to avoid testing the status of the URL which still fails with Composum / Sling.