### PR TITLE
Ignore possible exception when setting XML factory options

### DIFF
--- a/commons/content-package-builder/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/ContentPackage.java
+++ b/commons/content-package-builder/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/ContentPackage.java
@@ -85,11 +85,19 @@ public final class ContentPackage implements Closeable {
     this.zip = new ZipOutputStream(os);
 
     this.transformerFactory = TransformerFactory.newInstance();
-    this.transformerFactory.setAttribute("indent-number", 2);
+    try {
+      this.transformerFactory.setAttribute("indent-number", 2);
+    } catch (IllegalArgumentException e) {
+        // Implementation does not support configuration property. Ignore.
+    }
     try {
       this.transformer = transformerFactory.newTransformer();
-      this.transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-      this.transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+      try {
+        this.transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        this.transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+      } catch (IllegalArgumentException e) {
+        // Implementation does not support output property. Ignore.
+      }
     }
     catch (TransformerException ex) {
       throw new RuntimeException("Failed to set up XML transformer: " + ex.getMessage(), ex);


### PR DESCRIPTION
Some implementations do not support all config or output options.

E.g. `net.sf.saxon.TransformerFactoryImpl `throws on and
`com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl`
supports the `indent-number` config.

Since output formatting isn’t really relevant to the code working, failure
to set these properties should not be treated as a fatal error.