### PR TITLE
JCR Content Packager

### DIFF
--- a/maven/plugins/wcmio-content-package-maven-plugin/pom.xml
+++ b/maven/plugins/wcmio-content-package-maven-plugin/pom.xml
@@ -75,12 +75,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.wcm.tooling.commons</groupId>
-      <artifactId>io.wcm.tooling.commons.content-package-builder</artifactId>
-      <version>1.2.1-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
       <version>3.4</version>
@@ -89,6 +83,17 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
       <version>3.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit.vault</groupId>
+      <artifactId>org.apache.jackrabbit.vault</artifactId>
+      <version>3.1.18</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/maven/plugins/wcmio-content-package-maven-plugin/pom.xml
+++ b/maven/plugins/wcmio-content-package-maven-plugin/pom.xml
@@ -74,6 +74,22 @@
       <version>1.0.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>io.wcm.tooling.commons</groupId>
+      <artifactId>io.wcm.tooling.commons.content-package-builder</artifactId>
+      <version>1.2.1-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-archiver</artifactId>
+      <version>3.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-archiver</artifactId>
+      <version>3.1.1</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/PackageMojo.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/PackageMojo.java
@@ -34,6 +34,7 @@ import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.*;
@@ -60,7 +61,7 @@ import static org.apache.jackrabbit.vault.util.Constants.*;
   defaultPhase = LifecyclePhase.PACKAGE,
   requiresDependencyResolution = ResolutionScope.COMPILE
 )
-public final class PackageMojo extends AbstractContentPackageMojo {
+public final class PackageMojo extends AbstractMojo {
 
   public static final String ETC_PACKAGES = "/etc/packages";
 
@@ -310,10 +311,6 @@ public final class PackageMojo extends AbstractContentPackageMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    if (isSkip()) {
-      return;
-    }
-
     try {
       final File finalFile = new File(outputDirectory, finalName + PACKAGE_EXT);
       final File vaultFolder = new File(workDirectory, META_DIR);

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/PackageMojo.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/PackageMojo.java
@@ -1,0 +1,602 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2014 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.maven.plugins.contentpackage;
+
+import io.wcm.maven.plugins.contentpackage.pack.Dependency;
+import io.wcm.maven.plugins.contentpackage.pack.EmbeddedBundle;
+import io.wcm.maven.plugins.contentpackage.pack.JcrContentPackageArchiver;
+import io.wcm.maven.plugins.contentpackage.pack.NestedPackage;
+import org.apache.commons.io.IOUtils;
+import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
+import org.apache.jackrabbit.vault.fs.config.ConfigurationException;
+import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
+import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
+import org.apache.jackrabbit.vault.packaging.PackageId;
+import org.apache.maven.archiver.ManifestConfiguration;
+import org.apache.maven.archiver.MavenArchiveConfiguration;
+import org.apache.maven.archiver.MavenArchiver;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.*;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.*;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.apache.jackrabbit.vault.util.Constants.*;
+
+/**
+ * Creates a JCR Content Package with embedded Bundles and Packages.
+ *
+ * This goal requires that all content is placed under the <b>Work
+ * Directory</b> instead of the build output directory.
+ */
+@Mojo(
+  name = "package",
+  defaultPhase = LifecyclePhase.PACKAGE,
+  requiresDependencyResolution = ResolutionScope.COMPILE
+)
+public final class PackageMojo extends AbstractContentPackageMojo {
+
+  public static final String ETC_PACKAGES = "/etc/packages";
+
+  private static final String JCR_ROOT = "jcr_root/";
+  private static final String PACKAGE_TYPE = "zip";
+  private static final String PACKAGE_EXT = "." + PACKAGE_TYPE;
+  private static final String DEFINITION_FOLDER = "definition";
+  private static final DateFormat DATE_FORMAT = new SimpleDateFormat(
+    "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+  public static final String PROPERTY_GROUP = "group";
+  public static final String PROPERTY_NAME = "name";
+  public static final String PROPERTY_VERSION = "version";
+  public static final String PROPERTY_GROUP_ID = "groupId";
+  public static final String PROPERTY_ARTIFACT_ID = "artifactId";
+  public static final String PROPERTY_DEPENDENCIES = "dependencies";
+  public static final String PROPERTY_CREATED_BY = "createdBy";
+  public static final String PROPERTY_CREATED = "created";
+  public static final String PROPERTY_REQUIRES_ROOT = "requiresRoot";
+  public static final String PROPERTY_ALLOW_INDEX_DEFINITIONS = "allowIndexDefinitions";
+  public static final String PROPERTY_PATH = "path";
+  public static final String PROPERTY_AC_HANDLING = "acHandling";
+
+  @Component
+  private ArtifactHandlerManager artifactHandlerManager;
+
+  /**
+   * The Maven project.
+   */
+  @Parameter(property = "project", readonly = true, required = true)
+  private MavenProject project;
+
+  /**
+   * The archive configuration to use. See <a
+   * href="http://maven.apache.org/shared/maven-archiver/index.html">the
+   * documentation for Maven Archiver</a>.
+   */
+  @Parameter
+  private MavenArchiveConfiguration archive;
+
+  /**
+   * The directory containing the content to be packaged up into the content
+   * package. For now any content here is disregarded. Please copy the content
+   * into the workDirectory.
+   */
+  @Parameter(
+    defaultValue = "${project.build.outputDirectory}",
+    required = true)
+  private File builtContentDirectory;
+
+  /**
+   * The name of the generated package ZIP file without the ".zip" file
+   * extension.
+   */
+  @Parameter(
+    property = "vault.finalName",
+    defaultValue = "${project.build.finalName}",
+    required = true)
+  private String finalName;
+
+  /**
+   * Directory in which the built content package will be output.
+   */
+  @Parameter(
+    defaultValue="${project.build.directory}",
+    required = true)
+  private File outputDirectory;
+
+  /**
+   * The directory containing the content to be packaged up into the content
+   * package.
+   */
+  @Parameter(
+    defaultValue = "${project.build.directory}/vault-work",
+    required = true)
+  private File workDirectory;
+
+//TODO: Prefix not support yet
+//  /**
+//   * Adds a path prefix to all resources useful for shallower source trees.
+//   */
+//  @Parameter(property = "vault.prefix")
+//  private String prefix;
+
+  /**
+   * The group of the package (location where the package is installed)
+   */
+  @Parameter(
+    property = "vault.group",
+    defaultValue = "${project.groupId}",
+    required = true
+  )
+  private String group;
+
+  /**
+   * The name of the deployed package on the target server
+   */
+  @Parameter(
+    property = "vault.name",
+    defaultValue = "${project.artifactId}",
+    required = true
+  )
+  private String name;
+
+  /**
+   * The version of the artifact to install.
+   */
+  @Parameter(
+    property = "vault.version",
+    defaultValue = "${project.version}",
+    required = true
+  )
+  private String version;
+
+  /**
+   * Defines whether the package requires root. This will become the
+   * <code>requiresRoot</code> property of the properties.xml file.
+   */
+  @Parameter(
+    property = "vault.requiresRoot",
+    defaultValue="false",
+    required = true)
+  private boolean requiresRoot;
+
+  /**
+   * Defines whether the package is allowed to contain index definitions. This will become the
+   * <code>allowIndexDefinitions</code> property of the properties.xml file.
+   *
+   * As of now there is no check if any files contain index definitions if this is set to false
+   */
+  @Parameter(
+    property = "vault.allowIndexDefinitions",
+    defaultValue="false",
+    required = true)
+  private boolean allowIndexDefinitions;
+
+  /**
+   * Defines the AC Handling (see vault properties.xml file). It must be
+   * a String representation of the AccessControlHandling enum otherwise
+   * the packaging will fail.
+   */
+  @Parameter(
+    property = "vault.acHandling",
+    defaultValue="IGNORE",
+    required = false)
+  private AccessControlHandling acHandling;
+
+  /**
+   * Optional file that specifies the source of the workspace filter. The filters specified in the configuration
+   * and injected via emebedds or subpackages are merged into it.
+   */
+  @Parameter
+  private File filterSource;
+
+  /**
+   * list of embedded bundles
+   */
+  @Parameter
+  private final List<EmbeddedBundle> embeddeds = new ArrayList<EmbeddedBundle>();
+
+  /**
+   * Defines whether to fail the build when an embedded artifact is not
+   * found in the project's dependencies
+   * @since 0.0.12
+   */
+  @Parameter(
+    property = "vault.failOnMissingEmbed",
+    defaultValue = "false",
+    required = true
+  )
+  private boolean failOnMissingEmbed;
+
+  /**
+   * Defines the list of dependencies
+   */
+  @Parameter
+  private final List<Dependency> dependencies = new ArrayList<Dependency>();
+
+  /**
+   * Defines the list of nested packages.
+   */
+  @Parameter
+  private final List<NestedPackage> subPackages = new ArrayList<NestedPackage>();
+
+  /**
+   * Specifies additional properties to be set in the properties.xml file.
+   * These properties cannot overwrite the following predefined properties:
+   * <p>
+   * <table>
+   * <tr><td>group</td><td>Use <i>group</i> parameter to set</td></tr>
+   * <tr><td>name</td><td>Use <i>name</i> parameter to set</td></tr>
+   * <tr><td>version</td><td>Use <i>version</i> parameter to set</td></tr>
+   * <tr><td>groupId</td><td><i>groupId</i> of the Maven project descriptor</td></tr>
+   * <tr><td>artifactId</td><td><i>artifactId</i> of the Maven project descriptor</td></tr>
+   * <tr><td>dependencies</td><td>Use <i>dependencies</i> parameter to set</td></tr>
+   * <tr><td>createdBy</td><td>The value of the <i>user.name</i> system property</td></tr>
+   * <tr><td>created</td><td>The current system time</td></tr>
+   * <tr><td>requiresRoot</td><td>Use <i>requiresRoot</i> parameter to set</td></tr>
+   * <tr><td>allowIndexDefinitions</td><td>Use <i>allowIndexDefinitions</i> parameter to set</td></tr>
+   * <tr><td>packagePath</td><td>Automatically generated from the group and package name</td></tr>
+   * <tr><td>acHandling</td><td>Use <i>acHandling</i> parameter to set it</td></tr>
+   * </table>
+   */
+  @Parameter
+  private final Properties properties = new Properties();
+
+  /**
+   * Defines the path under which the embedded bundles are placed. defaults to '/apps/bundles/install'
+   * @since 0.0.6
+   */
+  @Parameter(property = "vault.embeddedTarget")
+  private String embeddedTarget;
+
+  public void addEmbedded(final EmbeddedBundle embeddedBundle) {
+    embeddeds.add(embeddedBundle);
+  }
+
+  public void addDependency(final Dependency dependency) {
+    dependencies.add(dependency);
+  }
+
+  public void addPackage(final NestedPackage nestedPackage) {
+    subPackages.add(nestedPackage);
+  }
+
+  public void setEmbeddedTarget(final String embeddedTarget) {
+    if (embeddedTarget.endsWith("/")) {
+      this.embeddedTarget = embeddedTarget;
+    } else {
+      this.embeddedTarget = embeddedTarget + "/";
+    }
+  }
+
+  private MavenArchiveConfiguration getMavenArchiveConfiguration() {
+    if (archive == null) {
+      archive = new MavenArchiveConfiguration();
+      archive.setManifest(new ManifestConfiguration());
+
+      archive.setAddMavenDescriptor(true);
+      archive.setCompress(true);
+      archive.setIndex(false);
+      archive.getManifest().setAddDefaultSpecificationEntries(true);
+      archive.getManifest().setAddDefaultImplementationEntries(true);
+    }
+
+    return archive;
+  }
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    if (isSkip()) {
+      return;
+    }
+
+    try {
+      final File finalFile = new File(outputDirectory, finalName + PACKAGE_EXT);
+      final File vaultFolder = new File(workDirectory, META_DIR);
+      final File vaultDefinitionFolder = new File(vaultFolder, DEFINITION_FOLDER);
+      vaultFolder.mkdirs();
+      vaultDefinitionFolder.mkdirs();
+
+      JcrContentPackageArchiver jcrContentPackageArchiver = new JcrContentPackageArchiver();
+      Map<String, File> additionalFiles = new HashMap<>();
+      DefaultWorkspaceFilter filter = null;
+      if (filterSource != null && filterSource.exists() && !filterSource.isDirectory()) {
+        filter = loadFilter(filterSource);
+      } else {
+        filter = loadFilterInFolder(vaultFolder);
+      }
+
+      obtainEmbeddedBundles(embeddeds, additionalFiles, filter);
+      obtainNestedPackages(subPackages, additionalFiles, filter);
+
+      File filterFile = new File(vaultFolder, "filter.xml");
+      // Reset the Filter to make sure the output is adjusted to any changes
+      filter.resetSource();
+      FileUtils.fileWrite(filterFile.getAbsolutePath(), filter.getSourceAsString());
+
+      writePropertiesFile(vaultFolder);
+      checkAndCopy(vaultFolder, CONFIG_XML);
+      checkAndCopy(vaultFolder, SETTINGS_XML);
+      checkAndCopy(vaultDefinitionFolder, DOT_CONTENT_XML);
+      jcrContentPackageArchiver.addDirectory(workDirectory);
+
+      // ensure that empty directories are included
+      jcrContentPackageArchiver.setIncludeEmptyDirs(true);
+      // Add additional files
+      for (Map.Entry<String, File> entry : additionalFiles.entrySet()) {
+        jcrContentPackageArchiver.addFile(entry.getValue(), entry.getKey());
+      }
+
+      MavenArchiver mavenArchiver = new MavenArchiver();
+      mavenArchiver.setArchiver(jcrContentPackageArchiver);
+      mavenArchiver.setOutputFile(finalFile);
+      mavenArchiver.createArchive(null, project, getMavenArchiveConfiguration());
+
+      final Artifact projectArtifact = project.getArtifact();
+      projectArtifact.setFile(finalFile);
+      projectArtifact.setArtifactHandler(artifactHandlerManager.getArtifactHandler(PACKAGE_TYPE));
+    } catch(Exception e) {
+      getLog().warn("Packaging Failed", e);
+      throw new MojoExecutionException(e.toString(), e);
+    }
+  }
+
+  private void obtainEmbeddedBundles(List<EmbeddedBundle> embeddedBundleList, Map<String, File> resultList, DefaultWorkspaceFilter filter)
+    throws IOException, MojoFailureException
+  {
+    for (EmbeddedBundle embeddedBundle : embeddedBundleList) {
+      final List<Artifact> artifacts = embeddedBundle.getMatchingArtifacts(project);
+      if (artifacts.isEmpty()) {
+        if (failOnMissingEmbed) {
+          throw new MojoFailureException("Embedded artifact: '" + embeddedBundle + "' but no dependency artifact found. Add the missing dependency or adjust the embedded definition.");
+        } else {
+          getLog().warn("No matching artifacts found for '" + embeddedBundle + "'");
+          continue;
+        }
+      }
+      if (embeddedBundle.getDestFileName() != null && artifacts.size() > 1) {
+        getLog().warn("Destination File Name defined but several artifacts match the '" + embeddedBundle + "'");
+      }
+
+      String embeddedTargetPath = embeddedBundle.getTarget();
+      if (embeddedTargetPath == null) {
+        embeddedTargetPath = embeddedTarget;
+        if (embeddedTargetPath == null) {
+          embeddedTargetPath = "/apps/bundles/install/";
+          getLog().info(
+            "No target path set for '" + embeddedBundle + "'. Using default '" + embeddedTargetPath + "'"
+          );
+        }
+      }
+      embeddedTargetPath = resolvePath(embeddedTargetPath);
+
+      embeddedTargetPath = JCR_ROOT + embeddedTargetPath;
+      embeddedTargetPath = FileUtils.normalize(embeddedTargetPath);
+
+      getLog().info("Embedding Bundle '" + embeddedBundle + "'");
+      for (final Artifact artifact : artifacts) {
+        final File source = artifact.getFile();
+        String destinationFileName = embeddedBundle.getDestFileName();
+        if (destinationFileName == null) {
+          destinationFileName = source.getName();
+        }
+        final String targetPathName = embeddedTargetPath + destinationFileName;
+        resultList.put(targetPathName, source);
+        final String targetNodePathName = targetPathName.substring(JCR_ROOT.length() - 1);
+        if (embeddedBundle.isGenerateFilter()) {
+          filter.add(new PathFilterSet(targetNodePathName));
+        }
+      }
+    }
+  }
+
+  private void obtainNestedPackages(List<NestedPackage> nestedPackageList, Map<String, File> resultList, DefaultWorkspaceFilter filter) throws IOException {
+    for (NestedPackage nestedPackage : nestedPackageList) {
+      final List<Artifact> artifacts = nestedPackage.getMatchingArtifacts(project);
+      if (artifacts.isEmpty()) {
+        getLog().warn("No matching artifacts for nested package: '" + nestedPackage + "'");
+        continue;
+      }
+
+      // get the package path
+      getLog().info("Adding Nested Package '" + nestedPackage + "'");
+      for (Artifact artifact : artifacts) {
+        final File source = artifact.getFile();
+
+        // load properties
+        ZipFile zipFile = null;
+        InputStream in = null;
+        Properties properties = new Properties();
+        try {
+          zipFile = new ZipFile(source, ZipFile.OPEN_READ);
+          ZipEntry zipEntry = zipFile.getEntry("META-INF/vault/properties.xml");
+          if (zipEntry == null) {
+            getLog().error("Package is invalid as it does not contain properties.xml");
+            throw new IOException("properties.xml missing in nested package: " + source.getName());
+          }
+          in = zipFile.getInputStream(zipEntry);
+          properties.loadFromXML(in);
+        } finally {
+          IOUtils.closeQuietly(in);
+          if (zipFile != null) {
+            zipFile.close();
+          }
+        }
+        PackageId pid = new PackageId(
+          properties.getProperty("group"),
+          properties.getProperty("name"),
+          properties.getProperty("version")
+        );
+        final String targetNodePathName = pid.getInstallationPath() + ".zip";
+        final String targetPathName = "jcr_root" + targetNodePathName;
+
+        resultList.put(targetPathName, source);
+        getLog().info("Embedding " + artifact.getId() + " -> " + targetPathName);
+        if (nestedPackage.isGenerateFilter()) {
+          filter.add(new PathFilterSet(targetNodePathName));
+        }
+      }
+    }
+  }
+
+  /**
+   * Build Package Properties XML file.
+   * @param vaultFolder Folder in where the properties.xml file is written to
+   * @throws IOException
+   */
+  private void writePropertiesFile(File vaultFolder)
+    throws IOException
+  {
+    final Properties vaultProperties = new Properties();
+
+    String description = project.getDescription();
+    if (description == null) {
+      description = project.getName();
+      if (description == null) {
+        description = project.getArtifactId();
+      }
+    }
+    vaultProperties.put("description", description);
+
+    // Add User Values first
+    for (Object propertyKey : properties.keySet()) {
+      if (properties.get(propertyKey) == null) {
+        properties.put(propertyKey, "");
+      }
+    }
+
+    vaultProperties.putAll(properties);
+
+    // Package Descriptions
+    vaultProperties.put(PROPERTY_GROUP, group);
+    vaultProperties.put(PROPERTY_NAME, name);
+    vaultProperties.put(PROPERTY_VERSION, version);
+
+    // Artifact Description
+    vaultProperties.put(PROPERTY_GROUP_ID, project.getGroupId());
+    vaultProperties.put(PROPERTY_ARTIFACT_ID, project.getArtifactId());
+
+    // Package Dependencies
+    if (!dependencies.isEmpty()) {
+      vaultProperties.put(PROPERTY_DEPENDENCIES, Dependency.toString(dependencies));
+    }
+
+    // User and Timestamp
+    if (!vaultProperties.containsKey(PROPERTY_CREATED_BY)) {
+      vaultProperties.put(PROPERTY_CREATED_BY, System.getProperty("user.name"));
+    }
+    vaultProperties.put(PROPERTY_CREATED, DATE_FORMAT.format(new Date()));
+
+    // configurable properties
+    vaultProperties.put(PROPERTY_REQUIRES_ROOT, String.valueOf(requiresRoot));
+    vaultProperties.put(PROPERTY_ALLOW_INDEX_DEFINITIONS, String.valueOf(allowIndexDefinitions));
+    vaultProperties.put(PROPERTY_PATH, ETC_PACKAGES + "/" + group + "/" + name + PACKAGE_EXT);
+    vaultProperties.put(PROPERTY_AC_HANDLING, acHandling.toString());
+
+    FileOutputStream fos = null;
+    try {
+      fos = new FileOutputStream(new File(vaultFolder, PROPERTIES_XML));
+      vaultProperties.storeToXML(fos, project.getName());
+    } finally {
+      fos.close();
+    }
+  }
+
+  private String resolvePath(final String path) {
+    String answer = path;
+    if (!answer.startsWith("/")) {
+      answer = "/"  + path;
+      getLog().info("Relative path resolved to " + answer);
+    }
+
+    return answer;
+  }
+
+  private File getFileFromFolder(File folder, final String fileName) {
+    File answer = null;
+    File[] files = folder.listFiles(
+      new FilenameFilter() {
+        @Override
+        public boolean accept(File dir, String name) {
+          return name.equals(fileName);
+        }
+      }
+    );
+    if (files.length > 0) {
+      answer = files[0];
+    }
+    return answer;
+  }
+
+  private void checkAndCopy(File vaultFolder, String fileName) throws IOException {
+    if (getFileFromFolder(vaultFolder, fileName) == null) {
+      InputStream ios = getClass().getResourceAsStream("/vault-file-templates/" + fileName);
+      if(ios != null) {
+        FileOutputStream fos = new FileOutputStream(new File(vaultFolder, fileName));
+        IOUtils.copy(
+          ios, fos
+        );
+        IOUtils.closeQuietly(ios);
+        IOUtils.closeQuietly(fos);
+      }
+    }
+  }
+
+  private DefaultWorkspaceFilter loadFilterInFolder(File vaultFolder)
+    throws IOException, ConfigurationException
+  {
+    return loadFilter(
+      vaultFolder != null && vaultFolder.exists() && vaultFolder.isDirectory() ?
+        new File(vaultFolder, FILTER_XML) :
+        null
+    );
+  }
+
+  private DefaultWorkspaceFilter loadFilter(File filterFile)
+    throws IOException, ConfigurationException
+  {
+    DefaultWorkspaceFilter answer = null;
+    InputStream in = null;
+    try {
+      if (filterFile != null && filterFile.exists() && !filterFile.isDirectory()) {
+        in = new FileInputStream(filterFile);
+      }
+      if (in != null) {
+        answer = new DefaultWorkspaceFilter();
+        answer.load(in);
+      }
+    } finally {
+      if(in != null) {
+        IOUtils.closeQuietly(in);
+      }
+    }
+    if(answer == null) {
+      answer = new DefaultWorkspaceFilter();
+    }
+    return answer;
+  }
+}

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/AbstractAddition.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/AbstractAddition.java
@@ -1,0 +1,65 @@
+package io.wcm.maven.plugins.contentpackage.pack;
+
+import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Common Properties for Embedded Bundles and Nested Packages
+ */
+public class AbstractAddition {
+  /**
+   * The Group Id of the Addition
+   */
+  protected String groupId;
+
+  /**
+   * Artifact Id of the Addition
+   */
+  protected String artifactId;
+
+  @Parameter
+  protected ScopeArtifactFilter scope;
+
+  @Parameter
+  protected String type;
+
+  @Parameter
+  protected String classifier;
+
+  @Parameter
+  protected boolean excludeTransitive;
+
+  /**
+   * If <code>true</code> a filter entry will be generated for this entry
+   */
+  @Parameter
+  protected boolean generateFilter;
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
+
+  public void setArtifactId(String artifactId) {
+    this.artifactId = artifactId;
+  }
+
+  public void setScope(String scope) {
+    this.scope = new ScopeArtifactFilter(scope);
+  }
+
+  public void setGenerateFilter(boolean generateFilter) {
+    this.generateFilter = generateFilter;
+  }
+
+  public boolean isGenerateFilter() {
+    return generateFilter;
+  }
+
+  public void setExcludeTransitive(boolean excludeTransitive) {
+    this.excludeTransitive = excludeTransitive;
+  }
+
+  public boolean isExcludeTransitive() {
+    return excludeTransitive;
+  }
+}

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/Dependency.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/Dependency.java
@@ -1,0 +1,88 @@
+package io.wcm.maven.plugins.contentpackage.pack;
+
+import org.apache.jackrabbit.vault.packaging.VersionRange;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.List;
+
+/**
+ * A dependency of the package which is added to the properties.xml
+ * file
+ */
+public class Dependency {
+
+  /**
+   * The group of the package dependency
+   */
+  @Parameter(
+    required = true
+  )
+  private String group;
+  /**
+   * The name of the package dependency
+   */
+  @Parameter(
+    required = true
+  )
+  private String name;
+  /**
+   * The version range
+   */
+  @Parameter
+  private VersionRange versionRange;
+
+  public String getGroup() {
+    return group;
+  }
+
+  public Dependency setGroup(String group) {
+    this.group = group;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Dependency setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public VersionRange getVersion() {
+    return versionRange;
+  }
+
+  public Dependency setVersion(String version) {
+    this.versionRange = VersionRange.fromString(version);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return "Dependency{" +
+      "group='" + group + '\'' +
+      ", name='" + name + '\'' +
+      ", versionRange=" + versionRange +
+      '}';
+  }
+
+  public String toVaultPropertyDependency() {
+    return group + ":" + name +
+      (versionRange != null ? ":" + versionRange.toString() : "");
+  }
+
+  public static String toString(List<Dependency> dependencies) {
+    boolean first = true;
+    StringBuilder b = new StringBuilder();
+    for (Dependency dependency: dependencies) {
+      if(first) {
+        first = false;
+      } else {
+        b.append(",");
+      }
+      b.append(dependency.toVaultPropertyDependency());
+    }
+    return b.toString();
+  }
+}

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/EmbeddedBundle.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/EmbeddedBundle.java
@@ -20,7 +20,6 @@
 package io.wcm.maven.plugins.contentpackage.pack;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/EmbeddedBundle.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/EmbeddedBundle.java
@@ -1,0 +1,123 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2014 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.maven.plugins.contentpackage.pack;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The <code>EmbeddedBundle</code> class represents an embedded bundle dependency
+ * from the project descriptor. An embedded bundle is declared as child <code>&lt;embedded&gt;</code>
+ * in the parent <code>&lt;embeddeds&gt;</code> like this:
+ * <p>
+ * <pre>
+ * &lt;embedded&gt;
+ * 	   &lt;groupId&gt;artifact.groupId&lt;/groupId&gt;
+ * 	   &lt;artifactId&gt;artifact.artifactId&lt;/artifactId&gt;
+ * 	   &lt;scope&gt;compile&lt;/scope&gt;
+ *     &lt;type&gt;jar&lt;/type&gt;
+ *     &lt;classifier&gt;sources&lt;/classifier&gt;
+ * 	   &lt;filter&gt;true&lt;/filter&gt;
+ * 	   &lt;target&gt;/libs/sling/install&lt;/target&gt;
+ * &lt;/embedded&gt;
+ * </pre>
+ */
+public class EmbeddedBundle
+  extends AbstractAddition
+{
+
+  /**
+   * JCR Location where the Bundle will be installed in
+   */
+  @Parameter
+  private String target;
+
+  /**
+   * Name to use for the bundle in the destination
+   */
+  @Parameter
+  private String destFileName;
+
+  public String getDestFileName() {
+    return destFileName;
+  }
+
+  public void setDestFileName(String destFileName) {
+    this.destFileName = destFileName;
+  }
+
+  public void setTarget(String target) {
+    // need trailing slash
+    if (!target.endsWith("/")) {
+      target += "/";
+    }
+
+    this.target = target;
+  }
+
+  public String getTarget() {
+    return target;
+  }
+
+  public List<Artifact> getMatchingArtifacts(final MavenProject project) {
+    // get artifacts depending on whether we exclude transitives or not
+    final Set<Artifact> dependencies;
+    if (excludeTransitive) {
+      // only direct dependencies, transitives excluded
+      dependencies = project.getDependencyArtifacts();
+    } else {
+      // all dependencies, transitives included
+      dependencies = project.getArtifacts();
+    }
+
+    final List<Artifact> matches = new ArrayList<Artifact>();
+    for (Artifact artifact : dependencies) {
+      if (groupId.contains(artifact.getGroupId())
+        && artifactId.contains(artifact.getArtifactId())
+        && (scope == null || scope.include(artifact))
+        && (type == null || type.equals(artifact.getType()))
+        && (classifier == null || classifier.equals(artifact.getClassifier()))) {
+        matches.add(artifact);
+      }
+    }
+    return matches;
+  }
+
+  @Override
+  public String toString() {
+    return "EmbeddedBundle{" +
+      "groupId='" + groupId + '\'' +
+      ", artifactId='" + artifactId + '\'' +
+      ", scope=" + scope +
+      ", type='" + type + '\'' +
+      ", classifier='" + classifier + '\'' +
+      ", generateFilter=" + generateFilter +
+      ", target='" + target + '\'' +
+      ", destFileName='" + destFileName + '\'' +
+      ", excludeTransitive=" + excludeTransitive +
+      '}';
+  }
+}

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/JcrContentPackageArchiver.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/JcrContentPackageArchiver.java
@@ -1,0 +1,31 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2014 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.maven.plugins.contentpackage.pack;
+
+import org.codehaus.plexus.archiver.jar.JarArchiver;
+
+public class JcrContentPackageArchiver extends JarArchiver {
+    
+    public JcrContentPackageArchiver() {
+        super();
+        archiveType = "content-package";
+    }
+
+}

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/NestedPackage.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/NestedPackage.java
@@ -1,0 +1,91 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2014 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.maven.plugins.contentpackage.pack;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The <code>NestedPackage</code> class represents an nested Package dependency
+ * from the project descriptor. Such an nested package is declared in
+ * <code>&lt;subPackage&gt;</code> elements inside the list style
+ * <code>&lt;subPackages&gt;</code> element as follows:
+ * <p>
+ * <pre>
+ * &lt;embedded&gt;
+ * 	   &lt;groupId&gt;artifact.groupId&lt;/groupId&gt;
+ * 	   &lt;artifactId&gt;artifact.artifactId&lt;/artifactId&gt;
+ * 	   &lt;scope&gt;compile&lt;/scope&gt;
+ *     &lt;type&gt;jar&lt;/type&gt;
+ *     &lt;classifier&gt;sources&lt;/classifier&gt;
+ * 	   &lt;filter&gt;true&lt;/filter&gt;
+ * &lt;/embedded&gt;
+ * </pre>
+ *
+ * @since 0.8
+ */
+public class NestedPackage
+  extends AbstractAddition
+{
+
+  public List<Artifact> getMatchingArtifacts(final MavenProject project) {
+    // Get the dependencies with or without transitives
+    final Set<Artifact> dependencies;
+    if (excludeTransitive) {
+      // only direct dependencies, transitives excluded
+      dependencies = project.getDependencyArtifacts();
+    } else {
+      // all dependencies, transitives included
+      dependencies = project.getArtifacts();
+    }
+
+    final List<Artifact> matches = new ArrayList<Artifact>();
+    for (Artifact dependency : dependencies) {
+      if (groupId.contains(dependency.getGroupId())
+        && artifactId.contains(dependency.getArtifactId())
+        && (scope == null || scope.include(dependency))
+        && (type == null || type.equals(dependency.getType()))
+        && (classifier == null || classifier.equals(dependency.getClassifier())))
+      {
+        matches.add(dependency);
+      }
+    }
+    return matches;
+  }
+
+  @Override
+  public String toString() {
+    return "NestedPackage{" +
+      "groupId='" + groupId + '\'' +
+      ", artifactId='" + artifactId + '\'' +
+      ", scope=" + scope +
+      ", type='" + type + '\'' +
+      ", classifier='" + classifier + '\'' +
+      ", generateFilter=" + generateFilter +
+      ", excludeTransitive=" + excludeTransitive +
+      '}';
+  }
+}

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/NestedPackage.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/pack/NestedPackage.java
@@ -20,8 +20,6 @@
 package io.wcm.maven.plugins.contentpackage.pack;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 import java.util.ArrayList;

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,60 @@
+<!--
+  #%L
+  wcm.io
+  %%
+  Copyright (C) 2016 wcm.io
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<component-set>
+  <components>
+    <component>
+      <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+      <role-hint>content-package</role-hint>
+      <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+      <configuration>
+        <lifecycles>
+          <lifecycle>
+            <id>default</id>
+            <!-- START SNIPPET: bundle-lifecycle -->
+            <phases>
+              <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
+              <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+              <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
+              <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+              <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+              <package>io.wcm.maven.plugins:wcmio-content-package-maven-plugin:package</package>
+              <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+              <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+            </phases>
+            <!-- END SNIPPET: bundle-lifecycle -->
+          </lifecycle>
+        </lifecycles>
+      </configuration>
+    </component>
+    <component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>content-package</role-hint>
+      <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+      <configuration>
+        <type>content-package</type>
+        <includesDependencies>true</includesDependencies>
+        <language>java</language>
+        <extension>zip</extension>
+        <packaging>content-package</packaging>
+        <addedToClasspath>true</addedToClasspath>
+      </configuration>
+    </component>
+  </components>
+</component-set>

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/resources/vault-file-templates/.content.xml
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/resources/vault-file-templates/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:vlt="http://www.day.com/jcr/vault/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+  jcr:primaryType="vlt:PackageDefinition"
+/>

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/resources/vault-file-templates/config.xml
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/resources/vault-file-templates/config.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2012 Adobe Systems Incorporated
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<vaultfs version="1.1">
+  <!--
+    Defines the content aggregation. The order of the defined aggregates
+    is important for finding the correct aggregator.
+  -->
+  <aggregates>
+    <!--
+      Defines an aggregate that handles nt:file and nt:resource nodes.
+    -->
+    <aggregate type="file" title="File Aggregate"/>
+    <!--
+      Defines an aggregate that handles file/folder like nodes. It matches
+      all nt:hierarchyNode nodes that have or define a jcr:content
+      child node and excludes child nodes that are nt:hierarchyNodes.
+    -->
+    <aggregate type="filefolder" title="File/Folder Aggregate"/>
+    <!--
+      Defines an aggregate that handles nt:nodeType nodes and serializes
+      them into .cnd notation.
+    -->
+    <aggregate type="nodetype" title="Node Type Aggregate"/>
+    <!--
+      Defines an aggregate that defines full coverage for certain node
+      types that cannot be covered by the default aggregator.
+    -->
+    <aggregate type="full" title="Full Coverage Aggregate">
+      <matches>
+        <include nodeType="rep:AccessControl" respectSupertype="true"/>
+        <include nodeType="rep:Policy" respectSupertype="true" />
+        <include nodeType="cq:Widget" respectSupertype="true"/>
+        <include nodeType="cq:WidgetCollection" respectSupertype="true"/>
+        <include nodeType="cq:EditConfig" respectSupertype="true"/>
+        <include nodeType="cq:WorkflowModel" respectSupertype="true"/>
+        <include nodeType="vlt:FullCoverage" respectSupertype="true"/>
+        <include nodeType="mix:language" respectSupertype="true"/>
+        <include nodeType="sling:OsgiConfig" respectSupertype="true"/>
+      </matches>
+    </aggregate>
+    <!--
+      Defines an aggregate that handles nt:folder like nodes.
+    -->
+    <aggregate type="generic" title="Folder Aggregate">
+      <matches>
+        <include nodeType="nt:folder" respectSupertype="true"/>
+      </matches>
+      <contains>
+        <exclude isNode="true"/>
+      </contains>
+    </aggregate>
+    <!--
+      Defines the default aggregate
+    -->
+    <aggregate type="generic" title="Default Aggregator" isDefault="true">
+      <matches>
+        <!-- all -->
+      </matches>
+      <contains>
+        <exclude nodeType="nt:hierarchyNode" respectSupertype="true"/>
+      </contains>
+    </aggregate>
+  </aggregates>
+  <!--
+    defines the input handlers
+  -->
+  <handlers>
+    <handler type="folder"/>
+    <handler type="file"/>
+    <handler type="nodetype"/>
+    <handler type="generic"/>
+  </handlers>
+</vaultfs>

--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/resources/vault-file-templates/settings.xml
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/resources/vault-file-templates/settings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2012 Adobe Systems Incorporated
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<vault version="1.0">
+  <ignore name=".svn"/>
+  <ignore name=".DS_Store"/>
+</vault>


### PR DESCRIPTION
Created a Mojo for the 'package' phase that will create a JCR Content Package as ZIP file, adding embedded bundles and nested packages comparable to Adobe's 'content-package-maven-plugin'.

There are a few slight differences:

- allowIndexDefinitions can be set but is not checked
- no support for patterns in the embedded bundles and nested packages for string patterns
- content must be placed inside the work directory (target/vault-work/jcr_root)
- filter property was renamed to 'generateFilter' to avoid the confusion with content filtering
- acHandling is now a Mojo property and must resolve to the AccessControlHandling enum from Jackrabbit 
- no support for 'prefix'

The rest is comparable including the requires packing type of 'content-bundle'.