### PR TITLE
Feature/exclude target in pmd

### DIFF
--- a/maven/global-build-tools/src/main/resources/global-build-tools/pmd-ruleset.xml
+++ b/maven/global-build-tools/src/main/resources/global-build-tools/pmd-ruleset.xml
@@ -31,6 +31,8 @@
 
   <!-- Exclude test classes -->
   <exclude-pattern>.*/src/test/.*</exclude-pattern>
+  <!-- Exclude target folder that may contain generated sources -->
+  <exclude-pattern>.*/target/.*</exclude-pattern>
 
   <rule ref="rulesets/java/empty.xml">
     <exclude name="EmptyCatchBlock"/>  <!-- false positives with empty blocks with comments as well -->

--- a/maven/global-parent/pom.xml
+++ b/maven/global-parent/pom.xml
@@ -471,6 +471,7 @@
             <encoding>UTF-8</encoding>
             <enableRulesSummary>false</enableRulesSummary>
             <linkXRef>true</linkXRef>
+            <excludes>**/target/**</excludes>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
exclude target folder from PMD and checkstyle checks, because target folder may contain generated sources that are declared as source folders in project