### PR TITLE
Feature/jdk 8212233

### DIFF
--- a/maven/global-parent/changes.xml
+++ b/maven/global-parent/changes.xml
@@ -22,7 +22,11 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
-
+    <release version="25">
+      <action type="update" dev="amuthmann">
+        Set source for javadoc plugin to fix issues when builing with jdk11+
+      </action>
+    </release>
     <release version="24" date="2019-01-16">
       <action type="update" dev="sseifert">
         Update to global-build-tools 17.

--- a/maven/global-parent/pom.xml
+++ b/maven/global-parent/pom.xml
@@ -190,6 +190,9 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <source>${build.compiler.source}</source>
+        </configuration>
       </plugin>
 
       <!-- Unit tests -->


### PR DESCRIPTION
We currently cannot build our project using jdk11 without setting the source for javadoc explicitly to 8. 
This is described in https://bugs.openjdk.java.net/browse/JDK-8212233