### PR TITLE
Allow newlines between entries in <packageFileList>

### DIFF
--- a/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/InstallMojo.java
+++ b/maven/plugins/wcmio-content-package-maven-plugin/src/main/java/io/wcm/maven/plugins/contentpackage/InstallMojo.java
@@ -183,7 +183,7 @@ public final class InstallMojo extends AbstractContentPackageMojo {
     else if (StringUtils.isNotBlank(packageFileList)) {
       String[] fileNames = StringUtils.split(packageFileList, ",");
       for (String fileName : fileNames) {
-        File file = new File(fileName);
+        File file = new File(StringUtils.trimToEmpty(fileName));
         items.add(toPackageFile(file));
       }
     }


### PR DESCRIPTION
Just a little trim to allow you to change
```
<packageFileList>
    some/really/long/path/to/a/file/somewhere/on/the/file/system.zip,some/absurdly/long/path/to/another/file/somewhere/else/i/mean/it/could/have/been/much/shorter/but/this/illustrates/the/point.zip
</packageFileList>
```
to the nicer
```
<packageFileList>
    some/really/long/path/to/a/file/somewhere/on/the/file/system.zip,
    some/absurdly/long/path/to/another/file/somewhere/else/i/mean/it/could/have/been/much/shorter/but/this/illustrates/the/point.zip
</packageFileList>
```