### PR TITLE
Add Version Info to Manifest

### DIFF
--- a/maven/global-parent/pom.xml
+++ b/maven/global-parent/pom.xml
@@ -585,6 +585,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.1.2</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
+            </archive>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
The maven-jar-plugin provides a nice way to add some build information to the Manifest which can be used later.
We'd need this change for a Spring Project using the p!v spring-global-parent but it might also help here, what do you think?

https://maven.apache.org/shared/maven-archiver/examples/manifest.html#Adding_Implementation_And_Specification_Details