### PR TITLE
Make ValueConverter public

### DIFF
--- a/commons/content-package-builder/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/ValueConverter.java
+++ b/commons/content-package-builder/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/ValueConverter.java
@@ -47,7 +47,7 @@ import org.apache.jackrabbit.vault.util.DocViewProperty;
 /**
  * Converts an value to string for a content property in XML including type prefix.
  */
-final class ValueConverter {
+public final class ValueConverter {
 
   static final String PN_PRIVILEGES = "rep:privileges";
 


### PR DESCRIPTION
I need this to be public to manually build parts of my content package. Currently, I’m simply copy-pasting the file into my project but it would be cool if I didn’t have to.