### PR TITLE
Adapt artifact name generator add-on heuristic to include commerce add-on packages

### DIFF
--- a/public_site/src/site/resources/util/aem-binary-artifact-name-generator.html
+++ b/public_site/src/site/resources/util/aem-binary-artifact-name-generator.html
@@ -117,7 +117,7 @@
 
         var aemSdkRegex = /^aem-sdk-(.+)\.zip$/;
         var aemSdkQuickstartRegex = /^aem-sdk-quickstart-(.+)\.jar$/;
-        var aemSdkAddonRegex = /^aem-.+-addon-(.+)\.zip$/;
+        var aemSdkAddonRegex = /^(aem|commerce)(-.+)*-addon-(.+)\.zip$$/;
 
         var coords = {};
 

--- a/public_site/src/site/resources/util/aem-binary-artifact-name-generator.html
+++ b/public_site/src/site/resources/util/aem-binary-artifact-name-generator.html
@@ -117,7 +117,7 @@
 
         var aemSdkRegex = /^aem-sdk-(.+)\.zip$/;
         var aemSdkQuickstartRegex = /^aem-sdk-quickstart-(.+)\.jar$/;
-        var aemSdkAddonRegex = /^(aem|commerce)(-.+)*-addon-(.+)\.zip$$/;
+        var aemSdkAddonRegex = /^(aem|commerce)(-.+)*-addon-(.+)\.zip$/;
 
         var coords = {};
 


### PR DESCRIPTION
The commerce add-ons are not recognized as such by the current regex (e.g. `commerce-addon-aem-650-all-2022.05.31.00.zip`) but categorized as "tooling".
This PR extends the regex to also include packages starting with `commerce-addon-*`
